### PR TITLE
Fix to attach comments for the template.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (tmpl, format) {
 		throw new gutil.PluginError('gulp-wrap-js', 'No template supplied');
 	}
 
-	tmpl = estemplate.compile(tmpl);
+	tmpl = estemplate.compile(tmpl, { attachComment:true });
 	format = format || escodegen.FORMAT_DEFAULTS;
 
 	return through.obj(function (file, enc, callback) {

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -1,3 +1,4 @@
+// template comment
 define(function () {
     var x = 1;
     var y = 2;

--- a/test/main.js
+++ b/test/main.js
@@ -25,7 +25,7 @@ describe('gulp-wrap-js', function () {
 	it('should produce expected file and source map', function (done) {
 		gulp.src('test/fixtures/index.js')
 		.pipe(sourcemaps.init())
-		.pipe(wrapJS('define(function () {%= body %});'))
+		.pipe(wrapJS('// template comment\ndefine(function () {%= body %});'))
 		.pipe(assert.first(function (file) {
 			file.contents.toString().should.eql(expectedFile.contents.toString());
 			file.sourceMap.sources.should.eql([file.relative]);


### PR DESCRIPTION
Comments from the wrapper template were being excluded and this fix attaches them during compile.