### PR TITLE
Allow access to vinyl file from within templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ module.exports = function (tmpl, format) {
 					comment: true
 				});
 				escodegen.attachComments(ast, ast.comments, ast.tokens);
+				ast.file = file;
 				ast = tmpl(ast);
 				var result = escodegen.generate(ast, {
 					comment: true,

--- a/test/expected/index.js
+++ b/test/expected/index.js
@@ -1,5 +1,5 @@
 // template comment
-define(function () {
+define('index.js', function () {
     var x = 1;
     var y = 2;
     // Comment

--- a/test/main.js
+++ b/test/main.js
@@ -25,9 +25,9 @@ describe('gulp-wrap-js', function () {
 	it('should produce expected file and source map', function (done) {
 		gulp.src('test/fixtures/index.js')
 		.pipe(sourcemaps.init())
-		.pipe(wrapJS('// template comment\ndefine(function () {%= body %});'))
+		.pipe(wrapJS('// template comment\ndefine("%= file.relative %", function () {%= body %});'))
 		.pipe(assert.first(function (file) {
-			file.contents.toString().should.eql(expectedFile.contents.toString());
+			file.contents.toString().should.eql(expectedFile.contents.toString().trim());
 			file.sourceMap.sources.should.eql([file.relative]);
 			file.sourceMap.file.should.eql(expectedFile.relative);
 			file.sourceMap.names.should.not.be.empty;


### PR DESCRIPTION
Let's you write templates like `define("%= file.relative %", ...)` which would translate to something like `define('my-module.js', ...)`
