### PR TITLE
[PR] Replace deprecated dependencies and methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var through = require('through2'),
-	gutil = require('gulp-util'),
+	colors = require('ansi-colors'),
+	PluginError = require('plugin-error'),
 	esprima = require('esprima'),
 	estemplate = require('estemplate'),
 	escodegen = require('escodegen'),
@@ -10,7 +11,7 @@ module.exports = function (tmpl, format) {
 	'use strict';
 
 	if (!tmpl) {
-		throw new gutil.PluginError('gulp-wrap-js', 'No template supplied');
+		throw new PluginError('gulp-wrap-js', 'No template supplied');
 	}
 
 	tmpl = estemplate.compile(tmpl, { attachComment:true });
@@ -25,7 +26,7 @@ module.exports = function (tmpl, format) {
 		}
 
 		if (file.isStream()) {
-			return callback(new gutil.PluginError('gulp-wrap-js', 'Stream content is not supported'));
+			return callback(new PluginError('gulp-wrap-js', 'Stream content is not supported'));
 		}
 
 		// check if file.contents is a `Buffer`
@@ -50,11 +51,11 @@ module.exports = function (tmpl, format) {
 				});
 			} catch(e) {
 				// Relative to gulpfile.js filepath with forward slashes
-				file = gutil.colors.magenta(path.relative('.', file.path).split(path.sep).join('/'));
-				return callback(new gutil.PluginError('gulp-wrap-js', file + ' ' + e.message))
+				file = colors.magenta(path.relative('.', file.path).split(path.sep).join('/'));
+				return callback(new PluginError('gulp-wrap-js', file + ' ' + e.message))
 			}
 
-			file.contents = new Buffer(result.code);
+			file.contents = Buffer.from(result.code);
 			if (file.sourceMap) {
 				applySourceMap(file, JSON.parse(result.map.toString()));
 			}

--- a/package.json
+++ b/package.json
@@ -21,19 +21,21 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
+    "ansi-colors": "^4.1.1",
     "escodegen": "^1.6.1",
     "esprima": "^2.3.0",
     "estemplate": "*",
-    "gulp-util": "~3.0.5",
+    "plugin-error": "^1.0.1",
     "through2": "*",
     "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
-    "gulp": "^3.9.0",
+    "gulp": "^4.0.2",
     "gulp-sourcemaps": "^1.5.2",
     "mocha": "*",
     "should": "^6.0.3",
-    "stream-assert": "^2.0.2"
+    "stream-assert": "^2.0.2",
+    "vinyl": "^2.2.0"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/test/main.js
+++ b/test/main.js
@@ -11,11 +11,11 @@ require('mocha');
 
 delete require.cache[require.resolve('../')];
 
-var gutil = require('gulp-util'),
+var File = require('vinyl'),
 	wrapJS = require('../');
 
 describe('gulp-wrap-js', function () {
-	var expectedFile = new gutil.File({
+	var expectedFile = new File({
 		path: 'test/expected/index.js',
 		cwd: 'test/',
 		base: 'test/expected',
@@ -27,7 +27,7 @@ describe('gulp-wrap-js', function () {
 		.pipe(sourcemaps.init())
 		.pipe(wrapJS('// template comment\ndefine("%= file.relative %", function () {%= body %});'))
 		.pipe(assert.first(function (file) {
-			file.contents.toString().should.eql(expectedFile.contents.toString().trim());
+			file.contents.toString().should.eql(expectedFile.contents.toString().replace(/\r\n/g, "\n").trim());
 			file.sourceMap.sources.should.eql([file.relative]);
 			file.sourceMap.file.should.eql(expectedFile.relative);
 			file.sourceMap.names.should.not.be.empty;


### PR DESCRIPTION
Apparently this package has not been maintained for quite some years, but I do think it's a good package and deserves to be maintained. Two years after this package's last update, it was announced that gulp-util was officially deprecated and any dependent packages should follow this [guideline](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) to fix it. That's basically what I did in this pull request. Please review it and hopefully we'll see a new version soon.